### PR TITLE
#133 - The number container of the progress tracker numbers needs to …

### DIFF
--- a/static/css/decodedarfur.css
+++ b/static/css/decodedarfur.css
@@ -148,9 +148,7 @@ p.progress-tracker-label {
 
 .progress-tracker-number {
     font-weight: bold;
-}
-.progress-tracker-number {
-    font-weight: bold;
+    margin: 26px;
 }
 
 .progress-modal-message{
@@ -531,6 +529,7 @@ p.progress-tracker-label {
   /** Progress Tracker **/
   .progress-tracker-number {
       font-size: 40px;
+      margin: 48px;
   }
 
   .progress-tracker-label {


### PR DESCRIPTION
…have a fixed height so that when the numbers do load they do not resize the div.
